### PR TITLE
Changed "ConnectionString" to "ConnectionStrings" to debug build error

### DIFF
--- a/HabitsHacked/Startup.cs
+++ b/HabitsHacked/Startup.cs
@@ -29,7 +29,7 @@ namespace HabitsHacked
 
             services.AddDbContext<TaskInfoContext>(options =>
             {
-                options.UseSqlite(Configuration["ConnectionString:TaskConnection"]);
+                options.UseSqlite(Configuration["ConnectionStrings:TaskConnection"]);
             });
         }
 


### PR DESCRIPTION
The app wouldn't build when I fetched everyone's changes at first, and I think it was because of a typo on the Startup.cs file. So I changed that and then it built just fine.